### PR TITLE
Correct a path in the build-gradle extension README

### DIFF
--- a/build-gradle/README.md
+++ b/build-gradle/README.md
@@ -6,7 +6,7 @@ Clone the repository and install the extension via the Phylum CLI.
 
 ```console
 git clone https://github.com/phylum-dev/community-extensions
-phylum extension install community-extensions/extensions/build-gradle/
+phylum extension install community-extensions/build-gradle/
 ```
 
 ## Running


### PR DESCRIPTION
Fix this small detail that was missed during #4