### PR TITLE
Add pip ecosystem extension

### DIFF
--- a/pip/PhylumExt.toml
+++ b/pip/PhylumExt.toml
@@ -3,8 +3,8 @@ description = "pip package manager hooks"
 entry_point = "main.ts"
 
 [permissions]
-run = ["/bin", "/usr/bin", "~/.pyenv"]
+run = ["./", "/bin", "/usr/bin", "~/.pyenv"]
 write = ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"]
-read = ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
+read = ["~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
 net = true
 unsandboxed_run = ["pip"]

--- a/pip/PhylumExt.toml
+++ b/pip/PhylumExt.toml
@@ -4,7 +4,7 @@ entry_point = "main.ts"
 
 [permissions]
 run = ["/bin", "/usr/bin", "~/.pyenv"]
-write = ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp"]
-read = ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
+write = ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"]
+read = ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
 net = true
 unsandboxed_run = ["pip"]

--- a/pip/PhylumExt.toml
+++ b/pip/PhylumExt.toml
@@ -3,8 +3,8 @@ description = "pip package manager hooks"
 entry_point = "main.ts"
 
 [permissions]
-run = ["/bin"]
-write = ["./", "~/.cache"]
-read = ["./", "~/.cache", "/etc/passwd"]
+run = ["/bin", "/usr/bin", "~/.pyenv"]
+write = ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp"]
+read = ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
 net = true
 unsandboxed_run = ["pip"]

--- a/pip/PhylumExt.toml
+++ b/pip/PhylumExt.toml
@@ -1,0 +1,10 @@
+name = "pip"
+description = "pip package manager hooks"
+entry_point = "main.ts"
+
+[permissions]
+run = ["/bin"]
+write = ["./", "~/.cache"]
+read = ["./", "~/.cache", "/etc/passwd"]
+net = true
+unsandboxed_run = ["pip"]

--- a/pip/README.md
+++ b/pip/README.md
@@ -1,0 +1,45 @@
+# Phylum pip extension
+
+A [Phylum CLI][phylum-cli] extension that checks your [pip] dependencies
+through [Phylum][phylum] before installing them.
+
+## Installation
+
+Clone the repository and install the extension via the Phylum CLI.
+
+```console
+git clone https://github.com/phylum-dev/community-extensions
+phylum extension install community-extensions/pip
+```
+
+## Basic usage
+
+Prepend `phylum` to your `pip` command invocations:
+
+```console
+phylum pip install my-package  # This will be checked by Phylum!
+```
+
+Or set up an alias in your shell to make it transparent:
+
+```console
+alias pip="phylum pip"
+pip install my-package  # This will be checked by Phylum!
+```
+
+## How it works
+
+When invoking `phylum pip`, subcommands that would install new packages trigger
+a Phylum analysis.
+
+- If the analysis is successful, the corresponding changes will be applied.
+- If the analysis is unsuccessful because some of the new dependencies don't
+  meet the required project thresholds, the command will fail.
+- If the analysis is waiting for Phylum to process one or more of the submitted
+  packages, the command will fail and the changes will _not_ be applied.
+- Commands that do not install any dependencies will be passed through to `pip`
+  directly.
+
+[phylum-cli]: https://github.com/phylum-dev/cli
+[phylum]: https://phylum.io
+[pip]: https://pip.pypa.io

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -5,25 +5,6 @@ import {
 } from "https://deno.land/std@0.150.0/fmt/colors.ts";
 import { PhylumApi } from "phylum";
 
-// Find project root directory.
-async function findRoot(manifest: string): Promise<string | undefined> {
-  let workingDir = Deno.cwd();
-
-  // Traverse up to 32 directories to find the root directory.
-  for (let i = 0; i < 32; i++) {
-    try {
-      // Check if manifest exists at location.
-      await Deno.stat(workingDir + "/" + manifest);
-      return workingDir;
-    } catch (_e) {
-      // Pop to parent if manifest doesn't exist.
-      workingDir += "/..";
-    }
-  }
-
-  return undefined;
-}
-
 // List with all of pip's subcommands.
 const knownSubcommands = [
   "install",

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -1,0 +1,158 @@
+import {
+  green,
+  red,
+  yellow,
+} from "https://deno.land/std@0.150.0/fmt/colors.ts";
+import { PhylumApi } from "phylum";
+
+// Find project root directory.
+async function findRoot(manifest: string): Promise<string | undefined> {
+  let workingDir = Deno.cwd();
+
+  // Traverse up to 32 directories to find the root directory.
+  for (let i = 0; i < 32; i++) {
+    try {
+      // Check if manifest exists at location.
+      await Deno.stat(workingDir + "/" + manifest);
+      return workingDir;
+    } catch (_e) {
+      // Pop to parent if manifest doesn't exist.
+      workingDir += "/..";
+    }
+  }
+
+  return undefined;
+}
+
+// List with all of pip's subcommands.
+const knownSubcommands = [
+  "install",
+  "download",
+  "uninstall",
+  "freeze",
+  "inspect",
+  "list",
+  "show",
+  "check",
+  "config",
+  "search",
+  "cache",
+  "index",
+  "wheel",
+  "hash",
+  "completion",
+  "debug",
+  "help",
+];
+
+// Ensure the first argument is a known subcommand.
+//
+// This prevents us from skipping the analysis when an argument is passed before
+// the first subcommand (i.e.: `pip --no-color install package`).
+const subcommand = Deno.args[0];
+if (Deno.args.length != 0 && !knownSubcommands.includes(subcommand)) {
+  console.error(`[${red("phylum")}] This extension does not support arguments before the first subcommand. Please open an issue if "${subcommand}" is not an argument.`);
+}
+
+// Ignore all commands that shouldn't be intercepted.
+if (Deno.args.length == 0 || subcommand != "install") {
+  const cmd = Deno.run({ cmd: ["pip", ...Deno.args] });
+  const status = await cmd.status();
+  Deno.exit(status.code);
+}
+
+// Analyze new dependencies with phylum before install/update.
+await checkDryRun();
+
+// Perform the package installation.
+const cmd = Deno.run({ cmd: ["pip", ...Deno.args] });
+const status = await cmd.status();
+Deno.exit(status.code);
+
+// Analyze new packages.
+async function checkDryRun() {
+  console.log(`[${green("phylum")}] Finding new dependencies…`);
+
+  const status = PhylumApi.runSandboxed({
+    cmd: "pip",
+    args: [...Deno.args, "--dry-run"],
+    exceptions: {
+      run: ["/bin"],
+      write: ["./", "~/.cache"],
+      read: ["./", "~/.cache", "/etc/passwd"],
+      net: true,
+    },
+    stdout: 'piped',
+  });
+
+  // Ensure dry-run was successful.
+  if (!status.success) {
+    console.error(`[${red("phylum")}] Pip dry-run failed.\n`);
+    await Deno.exit(status.code);
+  }
+
+  // Parse dry-run output.
+  let packages = parseDryRun(status.stdout);
+
+  console.log(`[${green("phylum")}] Dependency resolution successful.\n`);
+  console.log(`[${green("phylum")}] Analyzing packages…`);
+
+  if (packages.length === 0) {
+    console.log(`[${green("phylum")}] No new packages found for analysis.\n`);
+    return;
+  }
+
+  const jobId = await PhylumApi.analyze("pypi", packages);
+  const jobStatus = await PhylumApi.getJobStatus(jobId);
+
+  if (jobStatus.pass && jobStatus.status === "complete") {
+    console.log(`[${green("phylum")}] All packages pass project thresholds.\n`);
+  } else if (jobStatus.pass) {
+    console.warn(
+      `[${
+        yellow(
+          "phylum",
+        )
+      }] Unknown packages were submitted for analysis, please check again later.\n`,
+    );
+    Deno.exit(126);
+  } else {
+    console.error(
+      `[${red("phylum")}] The operation caused a threshold failure.\n`,
+    );
+    Deno.exit(127);
+  }
+}
+
+// Parse the dry-run output of `pip install`.
+function parseDryRun(output: string): [object] {
+  // Extract the "Would install [..]" line.
+  let new_deps;
+  const lines = output.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('Would install ')) {
+      new_deps = lines[i].substring('Would install '.length);
+      break;
+    }
+  }
+
+  // No "Would install [..]" means there were no new dependencies.
+  if (!new_deps) {
+    return [];
+  }
+
+  // Output package list.
+  const packages = [];
+
+  // Parse dependency names and versions.
+  const deps = new_deps.split(' ');
+  for (var i = 0; i < deps.length; i++) {
+    const dep = deps[i].split('-');
+    packages.push({
+      name: dep[0],
+      version: dep[1],
+    });
+  }
+
+  return packages;
+}

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -65,9 +65,17 @@ if (Deno.args.length == 0 || subcommand != "install") {
 await checkDryRun();
 
 // Perform the package installation.
-const cmd = Deno.run({ cmd: ["pip", ...Deno.args] });
-const status = await cmd.status();
-Deno.exit(status.code);
+const installStatus = PhylumApi.runSandboxed({
+  cmd: "pip",
+  args: Deno.args,
+  exceptions: {
+    run: ["/bin", "/usr/bin", "~/.pyenv"],
+    write: ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"],
+    read: ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
+    net: true,
+  },
+});
+Deno.exit(installStatus.code);
 
 // Analyze new packages.
 async function checkDryRun() {

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -129,9 +129,9 @@ function parseDryRun(output: string): [object] {
   // Extract the "Would install [..]" line.
   let new_deps;
   const lines = output.split('\n');
-  for (var i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith('Would install ')) {
-      new_deps = lines[i].substring('Would install '.length);
+  for (let line of lines) {
+    if (line.startsWith('Would install ')) {
+      new_deps = line.substring('Would install '.length);
       break;
     }
   }

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -77,9 +77,9 @@ async function checkDryRun() {
     cmd: "pip",
     args: [...Deno.args, "--dry-run"],
     exceptions: {
-      run: ["/bin"],
-      write: ["./", "~/.cache"],
-      read: ["./", "~/.cache", "/etc/passwd"],
+      run: ["/bin", "/usr/bin", "~/.pyenv"],
+      write: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp"],
+      read: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
       net: true,
     },
     stdout: 'piped',

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -67,7 +67,7 @@ async function checkDryRun() {
     args: [...Deno.args, "--dry-run"],
     exceptions: {
       run: ["./", "/bin", "/usr/bin", "~/.pyenv"],
-      write: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp"],
+      write: ["~/Library/Caches/pip", "~/.pyenv", "~/.cache", "~/.local/lib", "/tmp"],
       read: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
       net: true,
     },

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -50,9 +50,9 @@ const installStatus = PhylumApi.runSandboxed({
   cmd: "pip",
   args: Deno.args,
   exceptions: {
-    run: ["/bin", "/usr/bin", "~/.pyenv"],
+    run: ["./", "/bin", "/usr/bin", "~/.pyenv"],
     write: ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"],
-    read: ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
+    read: ["~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
     net: true,
   },
 });
@@ -66,7 +66,7 @@ async function checkDryRun() {
     cmd: "pip",
     args: [...Deno.args, "--dry-run"],
     exceptions: {
-      run: ["/bin", "/usr/bin", "~/.pyenv"],
+      run: ["./", "/bin", "/usr/bin", "~/.pyenv"],
       write: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp"],
       read: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
       net: true,


### PR DESCRIPTION
This patch adds an ecosystem extension for `pip`. This extension behaves a bit differently than the other ecosystem extension by making use of pip's `--dry-run` output. Instead of analyzing the full lockfile, only the new dependencies are analyzed.
