### PR TITLE
feat: add support for additional Python location on macOS

### DIFF
--- a/pip/PhylumExt.toml
+++ b/pip/PhylumExt.toml
@@ -3,7 +3,7 @@ description = "pip package manager hooks"
 entry_point = "main.ts"
 
 [permissions]
-run = ["./", "/bin", "/usr/bin", "~/.pyenv"]
+run = ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"]
 write = ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"]
 read = ["~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
 net = true

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -51,7 +51,7 @@ const installStatus = PhylumApi.runSandboxed({
   cmd: "pip",
   args: Deno.args,
   exceptions: {
-    run: ["./", "/bin", "/usr/bin", "~/.pyenv"],
+    run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
     write: ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"],
     read: ["~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
     net: true,
@@ -67,7 +67,7 @@ async function checkDryRun() {
     cmd: "pip",
     args: [...Deno.args, "--dry-run"],
     exceptions: {
-      run: ["./", "/bin", "/usr/bin", "~/.pyenv"],
+      run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
       write: ["~/Library/Caches/pip", "~/.pyenv", "~/.cache", "~/.local/lib", "/tmp"],
       read: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
       net: true,


### PR DESCRIPTION
This PR adds another, default, location on macOS for where the `python` binary can live.

