### PR TITLE
Switch pip extension to pip3

### DIFF
--- a/pip/PhylumExt.toml
+++ b/pip/PhylumExt.toml
@@ -7,4 +7,4 @@ run = ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"]
 write = ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"]
 read = ["~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
 net = true
-unsandboxed_run = ["pip"]
+unsandboxed_run = ["pip3"]

--- a/pip/PhylumExt.toml
+++ b/pip/PhylumExt.toml
@@ -4,7 +4,7 @@ entry_point = "main.ts"
 
 [permissions]
 run = ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"]
-write = ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"]
-read = ["~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
+write = ["./", "~/Library/Caches", "~/.cache", "~/.local", "~/.pyenv", "/tmp"]
+read = ["~/Library/Caches", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"]
 net = true
 unsandboxed_run = ["pip3"]

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -52,8 +52,8 @@ const installStatus = PhylumApi.runSandboxed({
   args: Deno.args,
   exceptions: {
     run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
-    write: ["./", "~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp"],
-    read: ["~/Library/Caches/pip", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
+    write: ["./", "~/Library/Caches", "~/.cache", "~/.local", "~/.pyenv", "/tmp"],
+    read: ["~/Library/Caches", "~/.cache", "~/.local", "~/.pyenv", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
     net: true,
   },
 });
@@ -68,8 +68,8 @@ async function checkDryRun() {
     args: [...Deno.args, "--dry-run"],
     exceptions: {
       run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
-      write: ["~/Library/Caches/pip", "~/.pyenv", "~/.cache", "~/.local/lib", "/tmp"],
-      read: ["~/Library/Caches/pip", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
+      write: ["~/Library/Caches", "~/.pyenv", "~/.cache", "~/.local/lib", "/tmp"],
+      read: ["~/Library/Caches", "~/.cache", "~/.local/lib", "/tmp", "/etc/passwd", "/etc/apache2/mime.types"],
       net: true,
     },
     stdout: 'piped',

--- a/pip/main.ts
+++ b/pip/main.ts
@@ -38,7 +38,7 @@ if (Deno.args.length != 0 && !knownSubcommands.includes(subcommand)) {
 
 // Ignore all commands that shouldn't be intercepted.
 if (Deno.args.length == 0 || subcommand != "install") {
-  const cmd = Deno.run({ cmd: ["pip", ...Deno.args] });
+  const cmd = Deno.run({ cmd: ["pip3", ...Deno.args] });
   const status = await cmd.status();
   Deno.exit(status.code);
 }
@@ -48,7 +48,7 @@ await checkDryRun();
 
 // Perform the package installation.
 const installStatus = PhylumApi.runSandboxed({
-  cmd: "pip",
+  cmd: "pip3",
   args: Deno.args,
   exceptions: {
     run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],
@@ -64,7 +64,7 @@ async function checkDryRun() {
   console.log(`[${green("phylum")}] Finding new dependencies…`);
 
   const status = PhylumApi.runSandboxed({
-    cmd: "pip",
+    cmd: "pip3",
     args: [...Deno.args, "--dry-run"],
     exceptions: {
       run: ["./", "/bin", "/usr/bin", "/usr/local/bin", "~/.pyenv"],


### PR DESCRIPTION
Some systems do not have `pip` symlinked to `pip3`. Since systems that do have it symlinked already usually still have `pip3`, the safest choice for invoking Python 3's pip should be executing `pip3`.

Since Python 2 is dead, we make no attempt to support it.
