### PR TITLE
Limit parallelization for snyk import extension

### DIFF
--- a/snyk-import/jobs.ts
+++ b/snyk-import/jobs.ts
@@ -1,0 +1,35 @@
+const DEFAULT_PARALLEL_COUNT = 8;
+
+/// Run the given function in parallel on the items in the input array.
+export async function inParallel<In, Out>(
+  input: In[],
+  fn: (i: In) => Promise<Out>,
+  parallel_count?: number,
+): Promise<Out[]> {
+  const output: Out[] = [];
+
+  parallel_count ||= DEFAULT_PARALLEL_COUNT;
+
+  // Start workers
+  const workers = [];
+  for (let i = 0; i < parallel_count; i++) {
+    workers.push(runWorker(input, output, fn));
+  }
+
+  // Wait for them to finish
+  await Promise.all(workers);
+
+  return output;
+}
+
+async function runWorker<In, Out>(
+  input: In[],
+  output: Out[],
+  fn: (i: In) => Promise<Out>,
+) {
+  while (true) {
+    const val = input.pop();
+    if (val === undefined) return;
+    output.push(await fn(val));
+  }
+}

--- a/snyk-import/lib.ts
+++ b/snyk-import/lib.ts
@@ -4,6 +4,7 @@ export const SNYK_API_URI = "https://api.snyk.io";
 /// Throw descriptive errors for REST API error responses.
 async function checkApiResponse(
   res: Response,
+  api_name: string,
   error_description: (body: string) => string,
 ): Promise<Response> {
   if (res.ok) {
@@ -18,13 +19,13 @@ async function checkApiResponse(
     msg = `HTTP ${res.status} received. Body: ${body}`;
   }
   const err = new Error(msg);
-  err.name = "API Error";
+  err.name = `${api_name} API Error`;
 
   throw err;
 }
 
 export const checkPhylumResponse = (res: Response) =>
-  checkApiResponse(res, (body) => JSON.parse(body).error.description);
+  checkApiResponse(res, "Phylum", (body) => JSON.parse(body).error.description);
 
 export const checkSnykResponse = (res: Response) =>
-  checkApiResponse(res, (body) => JSON.parse(body).errors[0].detail);
+  checkApiResponse(res, "Snyk", (body) => JSON.parse(body).errors[0].detail);


### PR DESCRIPTION
This should prevent the extension from running too fast and causing API failures (both in the Snyk API and our own).

