### PR TITLE
Add `snyk-import` link to main `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Community Extensions
 
-A collection of community extensions for the Phylum toolkit.
-These extensions expand Phylum's functionality even further than the
-[official extensions](https://github.com/phylum-dev/cli/tree/main/extensions).
-Some of these may be on their way to becoming official extensions.
-We hope you find them useful.
+A collection of community extensions for the Phylum toolkit. These extensions
+expand Phylum's functionality even further than the [official extensions](https://github.com/phylum-dev/cli/tree/main/extensions).
+Some of these may be on their way to becoming official extensions. We hope you
+find them useful.
 
 You can find the following extensions in the repository:
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # Community Extensions
-A collection of community extensions for the Phylum toolkit. These extensions
-expand Phylum's functionality even further than the [official extensions](https://github.com/phylum-dev/cli/tree/main/extensions).
-Some of these may be on their way to becoming official extensions. We hope you
-find them useful.
+
+A collection of community extensions for the Phylum toolkit.
+These extensions expand Phylum's functionality even further than the
+[official extensions](https://github.com/phylum-dev/cli/tree/main/extensions).
+Some of these may be on their way to becoming official extensions.
+We hope you find them useful.
 
 You can find the following extensions in the repository:
 
 * [`sarif`](./sarif/README.md) - Generate SARIF from a Phylum project
+* [`snyk-import`](./snyk-import/README.md) - Import projects from Snyk
 
 ## Contributions welcome
+
 If you have written an extension that you think others would find useful,
 please submit a PR!

--- a/sarif/README.md
+++ b/sarif/README.md
@@ -1,7 +1,6 @@
 # `sarif` Extension for Phylum
 
-This extension will take a Phylum project name (and optional group name),
-retrieve the JSON for the latest job and produce a valid SARIF output.
+This extension will take a Phylum project name (and optional group name), retrieve the JSON for the latest job and produce a valid SARIF output.
 
 ## Installation and Basic Usage
 

--- a/sarif/README.md
+++ b/sarif/README.md
@@ -1,7 +1,10 @@
 # `sarif` Extension for Phylum
-This extension will take a Phylum project name (and optional group name), retrieve the JSON for the latest job and produce a valid SARIF output.
+
+This extension will take a Phylum project name (and optional group name),
+retrieve the JSON for the latest job and produce a valid SARIF output.
 
 ## Installation and Basic Usage
+
 Clone the repository and install the extension via the Phylum CLI:
 
 ```console
@@ -10,10 +13,15 @@ phylum extension install community-extensions/sarif/
 ```
 
 ## Running
+
 To generate a SARIF file for a project, run:
 
-    phylum sarif --project <name>
+```sh
+phylum sarif --project <name>
+```
 
 Or optionally, if your project is in a group:
 
-    phylum sarif --project <name> --group <name>
+```sh
+phylum sarif --project <name> --group <name>
+```

--- a/snyk-import/README.md
+++ b/snyk-import/README.md
@@ -17,14 +17,14 @@ phylum extension install community-extensions/snyk-import/
 
 To import all of your current Snyk projects:
 
-```
+```sh
 phylum snyk-import --group <phylum_group>
 ```
 
 Or, setup a [Snyk service account] and use the token to import all projects in a
 Snyk org:
 
-```
+```sh
 SNYK_TOKEN=<service_token> phylum snyk-import --group <phylum_group>
 ```
 


### PR DESCRIPTION
This change adds the missing link to the `snyk-import` extension
in the main `README.md` file. It also cleans up all the README
files by formatting them consistently, with changes including:

* Ensure spacing between headings
* Use consistent (fenced) code block style throughout
* Ensure a language is specified for all fenced code blocks
