### PR TITLE
All project data export

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can find the following extensions in the repository:
 
 * [`sarif`](./sarif/README.md) - Generate SARIF from a Phylum project
 * [`snyk-import`](./snyk-import/README.md) - Import projects from Snyk
-* [`export`](./export/README.md) - Export all project data to a single JSON file 
+* [`export`](./export/README.md) - Export all project data to a single JSON file
 
 ## Contributions welcome
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can find the following extensions in the repository:
 
 * [`sarif`](./sarif/README.md) - Generate SARIF from a Phylum project
 * [`snyk-import`](./snyk-import/README.md) - Import projects from Snyk
+* [`export`](./export/README.md) - Export all project data to a single JSON file 
 
 ## Contributions welcome
 

--- a/export/PhylumExt.toml
+++ b/export/PhylumExt.toml
@@ -1,4 +1,5 @@
 name = "export"
+description = "Export all project data to a single JSON file"
 
 [permissions]
 net = true

--- a/export/PhylumExt.toml
+++ b/export/PhylumExt.toml
@@ -1,0 +1,5 @@
+name = "export"
+
+[permissions]
+net = true
+write = ["all-projects.json"]

--- a/export/README.md
+++ b/export/README.md
@@ -2,7 +2,6 @@
 
 This extension will iterate through your projects and export issue data for everything.
 
-
 ## Installation and Basic Usage
 
 Clone the repository and install the extension via the Phylum CLI:

--- a/export/README.md
+++ b/export/README.md
@@ -1,0 +1,27 @@
+# `export` Extension for Phylum
+
+This extension will iterate through your projects and export issue data for everything.
+
+
+## Installation and Basic Usage
+
+Clone the repository and install the extension via the Phylum CLI:
+
+```console
+git clone https://github.com/phylum-dev/community-extensions
+phylum extension install community-extensions/export/
+```
+
+## Running
+
+To export all project data, run:
+
+```sh
+phylum export 
+```
+
+Or optionally, if your project is in a group:
+
+```sh
+phylum export --group <name>
+```

--- a/export/README.md
+++ b/export/README.md
@@ -19,9 +19,3 @@ To export all project data, run:
 ```sh
 phylum export 
 ```
-
-Or optionally, if your project is in a group:
-
-```sh
-phylum export --group <name>
-```

--- a/export/main.ts
+++ b/export/main.ts
@@ -76,14 +76,14 @@ for (let i = 0; i < projects.length; i++) {
     }
 
     await bars.render([
-       {
-         completed: completed,
-         total: projects.length,
-         text: data.name ? data.name : "",
-         complete: "*",
-         incomplete: ".",
-       },
-     ]); 
+        {
+            completed: completed,
+            total: projects.length,
+            text: data.name ? data.name : "",
+            complete: "*",
+            incomplete: ".",
+        },
+    ]);
 
     allProjects[projectId] = data;
 }

--- a/export/main.ts
+++ b/export/main.ts
@@ -38,7 +38,7 @@ async function fetchProjects(cursor?: string, hasMore?: bool = true, perPage: in
         throw new Error(`Failed to fetch projects, HTTP error: ${response.status}`);
     }
 
-    const ret =  await response.json(); 
+    const ret = await response.json(); 
     const nextCursor = ret.values[ret.values.length - 1].id;
 
     return ret.values.concat(fetchProjects(nextCursor, ret.has_more));

--- a/export/main.ts
+++ b/export/main.ts
@@ -63,7 +63,7 @@ let completed = 0;
 let allProjects = {};
 
 // Iterate through projects and fetch project data
-for(let i = 0; i < projects.length; i++) {
+for (let i = 0; i < projects.length; i++) {
     let proj = projects[i];
     let projectId = proj.id;
     let groupName = proj.group_name;

--- a/export/main.ts
+++ b/export/main.ts
@@ -12,7 +12,7 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
         const response = await PhylumApi.fetch("v0/", url, {});
 
         if(!response.ok) {
-            console.error(`Failed to fetch project data, received HTTP error: ${response.status}`);
+            console.error(`\nFailed to fetch project data, received HTTP error: ${response.status}`);
         } else {
             const data = await response.json();
             return data;

--- a/export/main.ts
+++ b/export/main.ts
@@ -25,7 +25,7 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
 /** 
  * Iterate through the API and fetch all known projects. 
  */
-async function fetchProjects(cursor?: string, hasMore?: bool = true, perPage: int = 100): Promise<any> {
+async function fetchProjects(cursor?: string, hasMore: bool = true, perPage: int = 100): Promise<any> {
     if(!hasMore) {
         return [];
     }

--- a/export/main.ts
+++ b/export/main.ts
@@ -68,7 +68,7 @@ for (let i = 0; i < projects.length; i++) {
     let projectId = proj.id;
     let groupName = proj.group_name;
 
-    let data = await fetchProjectData(projectId, groupName); 
+    let data = await fetchProjectData(projectId, groupName);
     completed++;
 
     if(!data) {

--- a/export/main.ts
+++ b/export/main.ts
@@ -1,0 +1,89 @@
+import { PhylumApi } from 'phylum';
+import { parse } from "https://deno.land/std@0.156.0/flags/mod.ts";
+import { MultiProgressBar } from "https://deno.land/x/progress@v1.4.4/mod.ts";
+
+
+/**
+ * Fetch the project data from the Phylum API.
+ */
+async function fetchProjectData(projectId: string, group?: string): Promise<any> {
+    try {
+        const url = group ? `groups/${group}/projects/${projectId}` : `data/projects/${projectId}`;
+        const response = await PhylumApi.fetch("v0/", url, {});
+
+        if(!response.ok) {
+            console.error(`Failed to fetch project data, received HTTP error: ${response.status}`);
+        } else {
+            const data = await response.json();
+            return data;
+        }
+    } catch (error) {
+        console.error("There was an issue fetching the project data:", error);
+    }
+}
+
+/** 
+ * Iterate through the API and fetch all known projects. 
+ */
+async function fetchProjects(cursor?: string, hasMore?: bool = true, perPage: int = 100): Promise<any> {
+    if(!hasMore) {
+        return [];
+    }
+
+    const base = `/projects?paginate.limit=${perPage}`;
+    const projectsUrl = cursor ? `${base}&paginate.cursor=${cursor}` : base; 
+    const response = await PhylumApi.fetch("v0/", projectsUrl, {});
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch projects, HTTP error: ${response.status}`);
+    }
+
+    const ret =  await response.json(); 
+    const nextCursor = ret.values[ret.values.length - 1].id;
+
+    return ret.values.concat(fetchProjects(nextCursor, ret.has_more));
+}
+
+// Parse CLI args
+const args = parse(Deno.args);
+
+// Collect the list of projects
+const projects = await fetchProjects(); 
+console.log(`Found ${projects.length} projects in your account`);
+
+const bars = new MultiProgressBar({
+    title: "Downloading project data",
+    clear: true,
+    complete: "=",
+    incomplete: "-",
+    display: "[:bar] :text :percent :time :completed/:total",
+});
+
+let completed = 0;
+let allProjects = {};
+
+// Iterate through projects and fetch project data
+for(let i = 0; i < projects.length; i++) {
+    completed++;
+
+    let proj = projects[i];
+    let projectId = proj.id;
+    let groupName = proj.group_name;
+
+    let data = await fetchProjectData(projectId, groupName); 
+
+    await bars.render([
+       {
+         completed: completed,
+         total: projects.length,
+         text: "file1",
+         complete: "*",
+         incomplete: ".",
+       },
+     ]); 
+
+    allProjects[projectId] = data;
+}
+
+console.log("Writing project data to disk");
+Deno.writeTextFileSync("all-projects.json", JSON.stringify(allProjects));

--- a/export/main.ts
+++ b/export/main.ts
@@ -85,5 +85,5 @@ for(let i = 0; i < projects.length; i++) {
     allProjects[projectId] = data;
 }
 
-console.log("Writing project data to disk");
+console.log("\nWriting project data to disk");
 Deno.writeTextFileSync("all-projects.json", JSON.stringify(allProjects));

--- a/export/main.ts
+++ b/export/main.ts
@@ -18,7 +18,7 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
             return data;
         }
     } catch (error) {
-        console.error("There was an issue fetching the project data:", error);
+        console.error("\nThere was an issue fetching the project data:", error);
     }
 }
 

--- a/export/main.ts
+++ b/export/main.ts
@@ -11,7 +11,7 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
         const url = group ? `groups/${group}/projects/${projectId}` : `data/projects/${projectId}`;
         const response = await PhylumApi.fetch("v0/", url, {});
 
-        if(!response.ok) {
+        if (!response.ok) {
             console.error(`\nFailed to fetch project data, received HTTP error: ${response.status}`);
         } else {
             const data = await response.json();

--- a/export/main.ts
+++ b/export/main.ts
@@ -48,7 +48,7 @@ const args = parse(Deno.args);
 
 // Collect the list of projects
 console.log("Fetching projects list");
-const projects = await fetchProjects(); 
+const projects = await fetchProjects();
 console.log(`Found ${projects.length} projects in your account\n`);
 
 const bars = new MultiProgressBar({

--- a/export/main.ts
+++ b/export/main.ts
@@ -41,7 +41,10 @@ async function fetchProjects(cursor?: string, hasMore?: bool = true, perPage: in
     const ret = await response.json(); 
     const nextCursor = ret.values[ret.values.length - 1].id;
 
-    return ret.values.concat(fetchProjects(nextCursor, ret.has_more));
+    if (ret.has_more) {
+        return ret.values.concat(fetchProjects(nextCursor));
+    }
+    return ret.values;
 }
 
 // Parse CLI args

--- a/export/main.ts
+++ b/export/main.ts
@@ -23,7 +23,7 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
 }
 
 /**
- * Fetch a specific projects data.
+ * Fetch all known projects accessible to the current account.
  */
 async function fetchProjects(cursor?: string): Promise<any> {
     const base = `/projects?paginate.limit=100`;

--- a/export/main.ts
+++ b/export/main.ts
@@ -71,7 +71,7 @@ for (let i = 0; i < projects.length; i++) {
     let data = await fetchProjectData(projectId, groupName);
     completed++;
 
-    if(!data) {
+    if (!data) {
         continue;
     }
 


### PR DESCRIPTION
Adds an extension that iterates through all of a users projects. The project data is fetched for each project and the resulting JSON is stored such that the project key is the project ID and the value is the project JSON. This is saved to `all-projects.json` on disk.

Closes #36