### PR TITLE
Add `sarif` description

### DIFF
--- a/sarif/PhylumExt.toml
+++ b/sarif/PhylumExt.toml
@@ -1,4 +1,5 @@
 name = "sarif"
+description = "Generate SARIF from a Phylum project"
 
 [permissions]
 net = true


### PR DESCRIPTION
This change will enable the `sarif` extension description to show up in the output of `phylum help` as a command and `phylum extension list`.


<!--
Before submitting a PR:

1. Link the associated issue (i.e., `closes #<issueNum>` in description)
2. Ensure that you have met the expected acceptance criteria
3. Ensure that you have created sufficient tests
4. Ensure that you have updated all affected documentation
-->

