### PR TITLE
Add batching for writing files to disk for export

### DIFF
--- a/export/PhylumExt.toml
+++ b/export/PhylumExt.toml
@@ -1,5 +1,5 @@
 name = "export"
-description = "Export all project data to multiple JSON file"
+description = "Export all project data to JSON files"
 
 [permissions]
 net = true

--- a/export/PhylumExt.toml
+++ b/export/PhylumExt.toml
@@ -1,6 +1,6 @@
 name = "export"
-description = "Export all project data to a single JSON file"
+description = "Export all project data to multiple JSON file"
 
 [permissions]
 net = true
-write = ["all-projects.json"]
+write = ["./project_data"]

--- a/export/main.ts
+++ b/export/main.ts
@@ -64,8 +64,11 @@ async function fetchProjects(group?: string, cursor?: string): Promise<any> {
 
 // Parse CLI args
 const args = parse(Deno.args, {
-    alias: { group: ["g"] },
+    alias: { group: ["g"], batch: ["b"] },
     string: ["group"],
+    boolean: ["batch"],
+    negatable: ["batch"],
+    default: { "batch": true },
     unknown: (arg) => {
         console.error(`Unknown argument: ${arg}`);
         usage();
@@ -117,42 +120,27 @@ for(const proj of projects) {
     }));
 }
 
-function writeBatch(batchCount, data) {
-    const filename = `project_data/projectData.${batchCount}.json`;
-    console.log(`  Writing partial project data to ${filename}`);
+/**
+ * Write the provided data to disk.
+ */
+function writeBatch(name, data) {
+    const filename = `project_data/${name}.json`;
+    console.log(`  ${filename}`);
     Deno.writeTextFileSync(filename, JSON.stringify(data));
 }
-
-const MAX_JSON_STRING_LENGTH = 2097152;
 
 (async () => {
     await Promise.all(input);
     try {
-        Deno.mkdir("project_data");
+        await Deno.mkdir("project_data");
     } catch(e) {
         console.debug("`project_data` already exists");
     }
 
     console.log("\n\nWriting project data to `project_data/`");
 
-    let currentBatchSize = 0;
-    let currentBatchWrite = {};
-    let currentBatchIteration = 1;
-
     for(const projectId in allProjects) {
-        currentBatchWrite[projectId] = allProjects[projectId];
-        currentBatchSize += allProjects[projectId].length;
-
-        // If we're getting close to the max JSON string length (i.e., 75% of the maximum)
-        // write this batch to disk.
-        if(currentBatchSize > MAX_JSON_STRING_LENGTH * 0.75) {
-            writeBatch(currentBatchIteration, currentBatchWrite);
-            currentBatchIteration++;
-            currentBatchSize = 0;
-            currentBatchWrite = {};
-        }
+        const projectData = allProjects[projectId];
+        writeBatch(projectId, projectData);
     }
-
-    writeBatch(currentBatchIteration, currentBatchWrite);
-    console.log(`Wrote project data to ${currentBatchIteration} files`);
 })();

--- a/export/main.ts
+++ b/export/main.ts
@@ -64,11 +64,8 @@ async function fetchProjects(group?: string, cursor?: string): Promise<any> {
 
 // Parse CLI args
 const args = parse(Deno.args, {
-    alias: { group: ["g"], batch: ["b"] },
+    alias: { group: ["g"] },
     string: ["group"],
-    boolean: ["batch"],
-    negatable: ["batch"],
-    default: { "batch": true },
     unknown: (arg) => {
         console.error(`Unknown argument: ${arg}`);
         usage();
@@ -123,7 +120,7 @@ for(const proj of projects) {
 /**
  * Write the provided data to disk.
  */
-function writeBatch(name, data) {
+function writeProject(name, data) {
     const filename = `project_data/${name}.json`;
     console.log(`  ${filename}`);
     Deno.writeTextFileSync(filename, JSON.stringify(data));
@@ -141,6 +138,6 @@ function writeBatch(name, data) {
 
     for(const projectId in allProjects) {
         const projectData = allProjects[projectId];
-        writeBatch(projectId, projectData);
+        writeProject(projectId, projectData);
     }
 })();


### PR DESCRIPTION
For a large number of projects, writing everything out to a singular JSON file will exceed the maximum string length allowed. This update batches the writes such that each batch is under the maximum allowed length.
