### PR TITLE
Use the Snyk project ID as the label during import

### DIFF
--- a/snyk-import/main.ts
+++ b/snyk-import/main.ts
@@ -79,7 +79,7 @@ async function importProject(project: Project) {
     body: JSON.stringify({
       packages: dependencies,
       project: projectId,
-      label: "snyk-import",
+      label: project.id,
     }),
   }).then(checkPhylumResponse).then(async (res: any) => {
     const resp = await res.json();


### PR DESCRIPTION
Small change to use the Snyk ID for the label, instead of simply `snyk-import`.