### PR TITLE
Limit memory usage for the export

### DIFF
--- a/export/main.ts
+++ b/export/main.ts
@@ -125,12 +125,12 @@ function writeProject(name, data) {
 }
 
 (async () => {
-    await Promise.all(input);
     try {
         await Deno.mkdir("project_data");
     } catch(e) {
         console.debug("`project_data` already exists");
     }
 
+    await Promise.all(input);
     console.log("\n\nComplete");
 })();

--- a/export/main.ts
+++ b/export/main.ts
@@ -91,10 +91,9 @@ const bars = new MultiProgressBar({
 });
 
 let completed = 0;
-let allProjects = {};
 
 // Iterate through projects and fetch project data
-const limit = pLimit(7);
+const limit = pLimit(3);
 const input = [];
 
 for(const proj of projects) {
@@ -112,7 +111,7 @@ for(const proj of projects) {
            },
          ]); 
 
-        allProjects[proj.id] = data;
+        writeProject(proj.id, data);
         await delay(3);
     }));
 }
@@ -122,7 +121,6 @@ for(const proj of projects) {
  */
 function writeProject(name, data) {
     const filename = `project_data/${name}.json`;
-    console.log(`  ${filename}`);
     Deno.writeTextFileSync(filename, JSON.stringify(data));
 }
 
@@ -134,10 +132,5 @@ function writeProject(name, data) {
         console.debug("`project_data` already exists");
     }
 
-    console.log("\n\nWriting project data to `project_data/`");
-
-    for(const projectId in allProjects) {
-        const projectData = allProjects[projectId];
-        writeProject(projectId, projectData);
-    }
+    console.log("\n\nComplete");
 })();


### PR DESCRIPTION
Previously we were storing all project data as we retrieve it from the API, and then wrote to disk at the end. For user's with a large amount of projects, this can exhaust memory. This change writes to disk immediately, before moving onto the next project, without storing the project data in memory over the long term.

Additionally, we cut down parallelization to three (down from seven) to limit the activities happening at any given time.