### PR TITLE
Export project data against defined policy

### DIFF
--- a/export/main.ts
+++ b/export/main.ts
@@ -109,7 +109,7 @@ for(const proj of projects) {
         let msg = "";
 
         if(data) {
-            msg = data.name ? data.name.padEnd(50, ' ') : "".padEnd(50, ' ');
+            msg = data.name ? data.name : "";
             writeProject(proj.id, data);
         } else {
             msg = `Project '${proj.id}' has no job runs`;
@@ -121,7 +121,7 @@ for(const proj of projects) {
            {
              completed: completed,
              total: projects.length,
-             text: msg,
+             text: msg.padEnd(50, ' '),
              complete: "*",
              incomplete: ".",
            },

--- a/export/main.ts
+++ b/export/main.ts
@@ -111,7 +111,7 @@ for(const proj of projects) {
         let msg = "";
 
         if(data) {
-            msg = data.name ? data.name.padEnd(50, ' ') : "";
+            msg = data.name ? data.name.padEnd(50, ' ') : "".padEnd(50, ' ');
             writeProject(proj.id, data);
         } else {
             msg = `Project '${proj.id}' has no job runs`;

--- a/export/main.ts
+++ b/export/main.ts
@@ -32,10 +32,10 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
             const latestJobId = data.latestJobId;
 
             if(latestJobId) {
-                return evaluatePolicy(latestJobId, policy);
+                return await evaluatePolicy(latestJobId, policy);
             }
 
-            return data;
+            return null;
         }
     } catch (error) {
         console.error("\nThere was an issue fetching the project data:", error);
@@ -108,19 +108,27 @@ const input = [];
 for(const proj of projects) {
     input.push(limit(async () => {
         const data = await fetchProjectData(proj.id, proj.group_name)
+        let msg = "";
+
+        if(data) {
+            msg = data.name ? data.name.padEnd(50, ' ') : "";
+            writeProject(proj.id, data);
+        } else {
+            msg = `Project '${proj.id}' has no job runs`;
+        }
+
         completed++;
 
         bars.render([
            {
              completed: completed,
              total: projects.length,
-             text: data.name ? data.name.padEnd(50, ' ') : "",
+             text: msg,
              complete: "*",
              incomplete: ".",
            },
          ]); 
 
-        writeProject(proj.id, data);
         await delay(3);
     }));
 }

--- a/export/main.ts
+++ b/export/main.ts
@@ -3,7 +3,7 @@ import { parse } from "https://deno.land/std@0.156.0/flags/mod.ts";
 import { delay } from 'https://deno.land/x/delay@v0.2.0/mod.ts';
 import { MultiProgressBar } from "https://deno.land/x/progress@v1.4.4/mod.ts";
 import { pLimit } from "https://deno.land/x/p_limit@v1.0.0/mod.ts";
-import { fetchPolicy, evaluatePolicy } from './policy.ts';
+import { evaluatePolicy } from './policy.ts';
 
 function usage() {
     console.log("phylum export [--group phylum_group]");
@@ -18,8 +18,6 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
     }
 
     try {
-        const policy = await fetchPolicy(projectId, group);
-
         const url = group ? `groups/${group}/projects/${projectId}` : `data/projects/${projectId}`;
         const response = await PhylumApi.fetch("v0/", url, {});
 
@@ -32,7 +30,7 @@ async function fetchProjectData(projectId: string, group?: string): Promise<any>
             const latestJobId = data.latestJobId;
 
             if(latestJobId) {
-                return await evaluatePolicy(latestJobId, policy);
+                return await evaluatePolicy(latestJobId);
             }
 
             return null;

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -7,7 +7,7 @@ async function fetchPolicyRequest(url: string): Promise<string> {
     const response = await PhylumApi.fetch("v0/", url, {});
     
     if(!response.ok) {
-        console.error(`\nFailed to get the policy for project '${projectId}'`);
+        console.error(`\nFailed to get the policy for project`);
     } else {
         const data = await response.json();
         return data.preferences.policy;
@@ -40,17 +40,17 @@ async function fetchProjectPolicy(projectId: string): Promise<string> {
 /**
  * General function for fetching policy for a given project. Will first try to fetch a group
  * policy, then will fall back to the project policy. If no policy is specified, the Phylum
- * defaul policy is used.
+ * default policy is used.
  */
 export async function fetchPolicy(projectId: string, group?: string): Promise<string> {
     let policy = "";
 
     if(group) {
-        policy = fetchGroupPolicy(group);
+        policy = await fetchGroupPolicy(group);
     }
 
     if(!policy) {
-        policy = fetchProjectPolicy(projectId);
+        policy = await fetchProjectPolicy(projectId);
     } 
 
     return policy ? policy : await fetchDefaultPolicy();
@@ -60,7 +60,8 @@ export async function fetchPolicy(projectId: string, group?: string): Promise<st
  * Given a job ID and a policy, evaluate the job against the policy.
  */
 export async function evaluatePolicy(jobId: string, policy: string): Promise<any> {
-    const data = `{ "ignoredPackages":[], "policy": ${JSON.stringify(policy)} }`;
+    const data = JSON.stringify({"ignoredPackages":[], "policy": policy});
+
     let resp = await PhylumApi.fetch(
         "v0/",
         `data/jobs/${jobId}/policy/evaluate/raw`,
@@ -68,5 +69,4 @@ export async function evaluatePolicy(jobId: string, policy: string): Promise<any
     );
 
     return await resp.json();
-
 }

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -3,7 +3,7 @@ import { PhylumApi } from 'phylum';
 /**
  * Given a job ID and a policy, evaluate the job against the policy.
  */
-export async function evaluatePolicy(jobId: string, policy: string): Promise<any> {
+export async function evaluatePolicy(jobId: string): Promise<any> {
     const data = JSON.stringify({"ignoredPackages":[], "policy": {}});
 
     let resp = await PhylumApi.fetch(

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -6,7 +6,7 @@ import { PhylumApi } from 'phylum';
 async function fetchPolicyRequest(url: string): Promise<string> {
     const response = await PhylumApi.fetch("v0/", url, {});
     if(!response.ok) {
-        console.error(`\nFailed to get the policy for project`);
+        console.error(`\nFailed to get the policy`);
     } else {
         const data = await response.json();
         return data.preferences.policy;

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -1,0 +1,72 @@
+import { PhylumApi } from 'phylum';
+
+/**
+ * Helper function for fetching a policy from Phylum.
+ */
+async function fetchPolicyRequest(url: string): Promise<string> {
+    const response = await PhylumApi.fetch("v0/", url, {});
+    
+    if(!response.ok) {
+        console.error(`\nFailed to get the policy for project '${projectId}'`);
+    } else {
+        const data = await response.json();
+        return data.preferences.policy;
+    }
+
+    return "";
+}
+
+/**
+ * Fetches the current Phylum default policy.
+ */
+async function fetchDefaultPolicy(): Promise<string> {
+    return await fetchPolicyRequest("data/jobs/policy/default");
+}
+
+/**
+ * Fetches a group policy for the specified group.
+ */
+async function fetchGroupPolicy(group: string): Promise<string> {
+    return await fetchPolicyRequest(`preferences/group/${group}`);
+}
+
+/**
+ * Fetches the current policy from the specified project.
+ */
+async function fetchProjectPolicy(projectId: string): Promise<string> {
+    return await fetchPolicyRequest(`preferences/project/${projectId}`);
+}
+
+/**
+ * General function for fetching policy for a given project. Will first try to fetch a group
+ * policy, then will fall back to the project policy. If no policy is specified, the Phylum
+ * defaul policy is used.
+ */
+export async function fetchPolicy(projectId: string, group?: string): Promise<string> {
+    let policy = "";
+
+    if(group) {
+        policy = fetchGroupPolicy(group);
+    }
+
+    if(!policy) {
+        policy = fetchProjectPolicy(projectId);
+    } 
+
+    return policy ? policy : await fetchDefaultPolicy();
+}
+
+/**
+ * Given a job ID and a policy, evaluate the job against the policy.
+ */
+export async function evaluatePolicy(jobId: string, policy: string): Promise<any> {
+    const data = `{ "ignoredPackages":[], "policy": ${JSON.stringify(policy)} }`;
+    let resp = await PhylumApi.fetch(
+        "v0/",
+        `data/jobs/${jobId}/policy/evaluate/raw`,
+        { method: "POST", body: data }
+    );
+
+    return await resp.json();
+
+}

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -4,8 +4,6 @@ import { PhylumApi } from 'phylum';
  * Given a job ID and a policy, evaluate the job against the policy.
  */
 export async function evaluatePolicy(jobId: string): Promise<any> {
-    const data = JSON.stringify({"ignoredPackages":[], "policy": {}});
-
     let resp = await PhylumApi.fetch(
         `v0`,
         `/data/jobs/${jobId}/policy/evaluate/raw`,

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -5,7 +5,6 @@ import { PhylumApi } from 'phylum';
  */
 async function fetchPolicyRequest(url: string): Promise<string> {
     const response = await PhylumApi.fetch("v0/", url, {});
-    
     if(!response.ok) {
         console.error(`\nFailed to get the policy for project`);
     } else {

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -51,7 +51,7 @@ export async function fetchPolicy(projectId: string, group?: string): Promise<st
 
     if(!policy) {
         policy = await fetchProjectPolicy(projectId);
-    } 
+    }
 
     return policy ? policy : await fetchDefaultPolicy();
 }

--- a/export/policy.ts
+++ b/export/policy.ts
@@ -1,70 +1,20 @@
 import { PhylumApi } from 'phylum';
 
 /**
- * Helper function for fetching a policy from Phylum.
- */
-async function fetchPolicyRequest(url: string): Promise<string> {
-    const response = await PhylumApi.fetch("v0/", url, {});
-    if(!response.ok) {
-        console.error(`\nFailed to get the policy`);
-    } else {
-        const data = await response.json();
-        return data.preferences.policy;
-    }
-
-    return "";
-}
-
-/**
- * Fetches the current Phylum default policy.
- */
-async function fetchDefaultPolicy(): Promise<string> {
-    return await fetchPolicyRequest("data/jobs/policy/default");
-}
-
-/**
- * Fetches a group policy for the specified group.
- */
-async function fetchGroupPolicy(group: string): Promise<string> {
-    return await fetchPolicyRequest(`preferences/group/${group}`);
-}
-
-/**
- * Fetches the current policy from the specified project.
- */
-async function fetchProjectPolicy(projectId: string): Promise<string> {
-    return await fetchPolicyRequest(`preferences/project/${projectId}`);
-}
-
-/**
- * General function for fetching policy for a given project. Will first try to fetch a group
- * policy, then will fall back to the project policy. If no policy is specified, the Phylum
- * default policy is used.
- */
-export async function fetchPolicy(projectId: string, group?: string): Promise<string> {
-    let policy = "";
-
-    if(group) {
-        policy = await fetchGroupPolicy(group);
-    }
-
-    if(!policy) {
-        policy = await fetchProjectPolicy(projectId);
-    }
-
-    return policy ? policy : await fetchDefaultPolicy();
-}
-
-/**
  * Given a job ID and a policy, evaluate the job against the policy.
  */
 export async function evaluatePolicy(jobId: string, policy: string): Promise<any> {
-    const data = JSON.stringify({"ignoredPackages":[], "policy": policy});
+    const data = JSON.stringify({"ignoredPackages":[], "policy": {}});
 
     let resp = await PhylumApi.fetch(
-        "v0/",
-        `data/jobs/${jobId}/policy/evaluate/raw`,
-        { method: "POST", body: data }
+        `v0`,
+        `/data/jobs/${jobId}/policy/evaluate/raw`,
+        { 
+            method: "POST",
+            headers: {
+                "Content-Type": "", // Required to get this endpoint working correctly
+            }
+        }
     );
 
     return await resp.json();


### PR DESCRIPTION
This PR updates the exporter to only export issues that have caused a policy violation. The exporter will first attempt to pull the policy from the group level, before falling back to the project level policy. If no policy is defined, the default Phylum policy is used.